### PR TITLE
Update FPL proxy to Cloudflare worker

### DIFF
--- a/fpl/mini-league.html
+++ b/fpl/mini-league.html
@@ -12,7 +12,7 @@
 
         <script>
 
-            var url = 'http://cors-anywhere.herokuapp.com/';
+            var url = 'https://silent-fire-4c34.inclind.workers.dev';
 
             $('#getLeagueData').on('click', function(){
                 $('#loadingChart').slideDown();
@@ -105,7 +105,7 @@
 
 
                 $.ajax({
-                    url:url, data:{url:'https://fantasy.premierleague.com/drf/leagues-classic-standings/' + leagueId + '?phase=1'}, 
+                    url: url + '/drf/leagues-classic-standings/' + leagueId + '?phase=1', 
                     success:function(data){
             console.log(data);
                     //build the chart Y axes
@@ -126,266 +126,266 @@
                         var fish = $.each(playerIds, function(i, val){
 
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/1/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/1/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw1.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/2/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/2/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw2.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/3/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/3/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw3.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/4/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/4/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw4.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/5/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/5/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw5.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/6/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/6/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw6.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/7/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/7/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw7.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/8/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/8/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw8.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/9/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/9/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw9.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/10/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/10/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw10.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/11/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/11/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw11.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/12/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/12/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw12.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/13/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/13/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw13.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/14/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/14/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw14.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/15/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/15/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw15.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/16/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/16/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw16.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/17/picks'},
+                            url: url + '/drf/entry/'+val+'/event/17/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw17.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/18/picks'},
+                            url: url + '/drf/entry/'+val+'/event/18/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw18.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/19/picks'},
+                            url: url + '/drf/entry/'+val+'/event/19/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw19.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/20/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/20/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw20.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/21/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/21/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw21.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/22/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/22/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw22.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/23/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/23/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw23.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/24/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/24/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw24.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/25/picks'},
+                            url: url + '/drf/entry/'+val+'/event/25/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw25.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/26/picks'},
+                            url: url + '/drf/entry/'+val+'/event/26/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw26.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/27/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/27/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw27.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/28/picks'},
+                            url: url + '/drf/entry/'+val+'/event/28/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw28.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/29/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/29/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw29.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/30/picks'},
+                            url: url + '/drf/entry/'+val+'/event/30/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw30.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/31/picks'},
+                            url: url + '/drf/entry/'+val+'/event/31/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw31.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/32/picks'},
+                            url: url + '/drf/entry/'+val+'/event/32/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw32.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/33/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/33/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw33.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/34/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/34/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw34.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/35/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/35/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw35.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/36/picks'},
+                            url: url + '/drf/entry/'+val+'/event/36/picks',
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw36.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/37/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/37/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw37.push(points)
                                 }
                             })
                         $.ajax({
-                            url:url, data:{url:'https://fantasy.premierleague.com/drf/entry/'+val+'/event/38/picks'}, 
+                            url: url + '/drf/entry/'+val+'/event/38/picks', 
                             success:function(data){
                                 points = data.entry_history.total_points;
                                 gw38.push(points)
@@ -536,7 +536,7 @@
                         },
 
                         componentDidMount() {
-                            fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/bootstrap-static/", {
+                            fetch("https://silent-fire-4c34.inclind.workers.dev/api/bootstrap-static/", {
                                 headers: {
                                     'x-requested-with': 'testing',
                                 },
@@ -562,7 +562,7 @@
                                         (result) => {
                                             this.historyArray = [];
                                             for (var i = 1; i < 38; i++) {
-                                                fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/event/" + i + "/live/", {
+                                                fetch("https://silent-fire-4c34.inclind.workers.dev/api/event/" + i + "/live/", {
                                                     headers: {
                                                         'x-requested-with': 'testing',
                                                     },
@@ -602,7 +602,7 @@
                                 })
 
 
-                                fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/leagues-classic/" + this.state.leagueId + "/standings/", {
+                                fetch("https://silent-fire-4c34.inclind.workers.dev/api/leagues-classic/" + this.state.leagueId + "/standings/", {
                                         headers: {
                                             'x-requested-with': 'testing',
                                         },
@@ -649,7 +649,7 @@
                             this.state.playerArray = [];
                             let outfieldscore = '';
 
-                            const url = 'http://cors-anywhere.herokuapp.com/';
+                            const url = 'https://silent-fire-4c34.inclind.workers.dev';
 
                             let goalsScored = 0;
                             let assists = 0;
@@ -668,9 +668,9 @@
 
                             for (let b = 1; b <= this.state.historyData.length; b++) {
                                 Promise.all([
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/"),
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/history/"),
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/event/" + b + "/picks/")
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/api/entry/" + teamId + "/"),
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/api/entry/" + teamId + "/history/"),
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/api/entry/" + teamId + "/event/" + b + "/picks/")
                                 ])
                                     //  fetch(url + "?csurl=https://fantasy.premierleague.com/api/entry/" + teamId +"/")
                                     .then(([res1, res2, res3]) => Promise.all([res1.json(), res2.json(), res3.json()]))


### PR DESCRIPTION
## Summary
- switch mini-league data requests to the Cloudflare worker proxy

## Testing
- `grep -n "cors-anywhere" -n fpl/mini-league.html`
- `grep -n "silent-fire" -n fpl/mini-league.html | head`
