### PR TITLE
Fix FPL proxy and stats error

### DIFF
--- a/fpl/mini-league.html
+++ b/fpl/mini-league.html
@@ -12,7 +12,7 @@
 
         <script>
 
-            var url = 'http://cors-anywhere.herokuapp.com/';
+            var url = 'https://silent-fire-4c34.inclind.workers.dev/';
 
             $('#getLeagueData').on('click', function(){
                 $('#loadingChart').slideDown();
@@ -536,7 +536,7 @@
                         },
 
                         componentDidMount() {
-                            fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/bootstrap-static/", {
+                            fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/bootstrap-static/", {
                                 headers: {
                                     'x-requested-with': 'testing',
                                 },
@@ -562,7 +562,7 @@
                                         (result) => {
                                             this.historyArray = [];
                                             for (var i = 1; i < 38; i++) {
-                                                fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/event/" + i + "/live/", {
+                                                fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/event/" + i + "/live/", {
                                                     headers: {
                                                         'x-requested-with': 'testing',
                                                     },
@@ -602,7 +602,7 @@
                                 })
 
 
-                                fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/leagues-classic/" + this.state.leagueId + "/standings/", {
+                                fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/leagues-classic/" + this.state.leagueId + "/standings/", {
                                         headers: {
                                             'x-requested-with': 'testing',
                                         },
@@ -649,7 +649,7 @@
                             this.state.playerArray = [];
                             let outfieldscore = '';
 
-                            const url = 'http://cors-anywhere.herokuapp.com/';
+                            const url = 'https://silent-fire-4c34.inclind.workers.dev/';
 
                             let goalsScored = 0;
                             let assists = 0;
@@ -668,9 +668,9 @@
 
                             for (let b = 1; b <= this.state.historyData.length; b++) {
                                 Promise.all([
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/"),
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/history/"),
-                                    fetch("http://cors-anywhere.herokuapp.com/https://fantasy.premierleague.com/api/entry/" + teamId + "/event/" + b + "/picks/")
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/entry/" + teamId + "/"),
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/entry/" + teamId + "/history/"),
+                                    fetch("https://silent-fire-4c34.inclind.workers.dev/https://fantasy.premierleague.com/api/entry/" + teamId + "/event/" + b + "/picks/")
                                 ])
                                     //  fetch(url + "?csurl=https://fantasy.premierleague.com/api/entry/" + teamId +"/")
                                     .then(([res1, res2, res3]) => Promise.all([res1.json(), res2.json(), res3.json()]))
@@ -684,22 +684,25 @@
                                             let counter = 0;
                                             let location = b - 1;
                                             for (var q = 0; q < 11; q++) {
-                                                if (this.state.historyData[location].length) {
+                                                if (this.state.historyData[location] && this.state.historyData[location].length && res3.picks && res3.picks[q]) {
                                                     let thisPlayer = res3.picks[q].element - 1;
-                                                    let thisPlayerData = this.state.historyData[location][thisPlayer].stats;
+                                                    let playerEntry = this.state.historyData[location][thisPlayer];
+                                                    if (playerEntry && playerEntry.stats) {
+                                                        let thisPlayerData = playerEntry.stats;
 
-                                                    goalsScored += thisPlayerData.goals_scored;
-                                                    bps += thisPlayerData.bonus;
-                                                    conceded += thisPlayerData.goals_conceded;
-                                                    minutes += thisPlayerData.minutes;
-                                                    ownGoals += thisPlayerData.own_goals;
-                                                    penaltiesMissed += thisPlayerData.penalties_missed;
-                                                    penaltiesSaved += thisPlayerData.penalties_saved;
-                                                    redCards += thisPlayerData.red_cards;
-                                                    saves += thisPlayerData.saves;
-                                                    yellows += thisPlayerData.yellow_cards;
-                                                    cleanSheets += thisPlayerData.clean_sheets;
-                                                    assists += thisPlayerData.assists;
+                                                        goalsScored += thisPlayerData.goals_scored;
+                                                        bps += thisPlayerData.bonus;
+                                                        conceded += thisPlayerData.goals_conceded;
+                                                        minutes += thisPlayerData.minutes;
+                                                        ownGoals += thisPlayerData.own_goals;
+                                                        penaltiesMissed += thisPlayerData.penalties_missed;
+                                                        penaltiesSaved += thisPlayerData.penalties_saved;
+                                                        redCards += thisPlayerData.red_cards;
+                                                        saves += thisPlayerData.saves;
+                                                        yellows += thisPlayerData.yellow_cards;
+                                                        cleanSheets += thisPlayerData.clean_sheets;
+                                                        assists += thisPlayerData.assists;
+                                                    }
                                                 }
                                                 counter = counter + 1;
                                             }


### PR DESCRIPTION
## Summary
- switch FPL requests to use the Cloudflare Worker proxy
- guard against undefined player stats when aggregating scores

## Testing
- `grep -n "silent-fire" -n fpl/mini-league.html`
